### PR TITLE
Debug mpi surpressed w

### DIFF
--- a/src/comm_windows/comm_windows.h
+++ b/src/comm_windows/comm_windows.h
@@ -10,13 +10,13 @@
 
 
 void CommWindows_Create(struct CommWindows **comm_windows_addr,
-                        struct Clusters *clusters, struct Particles *sources);
+                        struct Clusters *clusters, struct Particles *sources, struct RunParams *run_params);
 
-void CommWindows_Free(struct CommWindows **comm_windows_addr);
+void CommWindows_Free(struct CommWindows **comm_windows_addr, struct RunParams *run_params);
 
-void CommWindows_Lock(struct CommWindows *comm_windows, int get_from);
+void CommWindows_Lock(struct CommWindows *comm_windows, int get_from, struct RunParams *run_params);
 
-void CommWindows_Unlock(struct CommWindows *comm_windows, int get_from);
+void CommWindows_Unlock(struct CommWindows *comm_windows, int get_from, struct RunParams *run_params);
 
 void CommWindows_GetData(struct Clusters *let_clusters, struct Particles *let_sources,
                          struct CommTypes *comm_types, struct CommWindows *comm_windows,

--- a/src/drivers/treedriver.c
+++ b/src/drivers/treedriver.c
@@ -377,25 +377,25 @@ void treedriver(struct Particles *sources, struct Particles *targets, struct Run
             }
 #endif
             CommTypesAndTrees_Construct(&comm_types, &let_trees, tree, batches, run_params);
-
             Particles_Alloc(&let_sources, comm_types->let_sources_length);
             Clusters_Alloc(&let_clusters, comm_types->let_clusters_length, run_params);
                                                     
-            CommWindows_Create(&comm_windows, clusters, sources);
+            CommWindows_Create(&comm_windows, clusters, sources, run_params);
             
             for (int proc_id = 1; proc_id < num_procs; ++proc_id) {
             
                 int get_from = (num_procs + rank - proc_id) % num_procs;
                 
-                CommWindows_Lock(comm_windows, get_from);
+                CommWindows_Lock(comm_windows, get_from, run_params);
                 // This is a non-blocking call!
                 CommWindows_GetData(let_clusters, let_sources, comm_types, comm_windows, get_from, run_params);
-                CommWindows_Unlock(comm_windows, get_from);
+                CommWindows_Unlock(comm_windows, get_from, run_params);
             }
             
-            CommWindows_Free(&comm_windows);
+            CommWindows_Free(&comm_windows, run_params);
             STOP_TIMER(&time_tree[3]);
         }
+
 
         //~~~~~~~~~~~~~~~~~~~~
         // Local compute
@@ -650,19 +650,19 @@ void treedriver(struct Particles *sources, struct Particles *targets, struct Run
             Particles_Alloc(&let_sources, comm_types->let_sources_length);
             Clusters_Alloc(&let_clusters, comm_types->let_clusters_length, run_params);
                                                       
-            CommWindows_Create(&comm_windows, source_clusters, sources);
+            CommWindows_Create(&comm_windows, source_clusters, sources, run_params);
             
             for (int proc_id = 1; proc_id < num_procs; ++proc_id) {
 
                 int get_from = (num_procs + rank - proc_id) % num_procs;
                 
-                CommWindows_Lock(comm_windows, get_from);
+                CommWindows_Lock(comm_windows, get_from, run_params);
                 //This is a non-blocking call!
                 CommWindows_GetData(let_clusters, let_sources, comm_types, comm_windows, get_from, run_params);
-                CommWindows_Unlock(comm_windows, get_from);
+                CommWindows_Unlock(comm_windows, get_from, run_params);
             }
             
-            CommWindows_Free(&comm_windows);
+            CommWindows_Free(&comm_windows, run_params);
             STOP_TIMER(&time_tree[3]);
         }
 

--- a/src/interaction_compute/interaction_compute_downpass.c
+++ b/src/interaction_compute/interaction_compute_downpass.c
@@ -62,7 +62,7 @@ void InteractionCompute_Downpass(double *potential, struct Tree *tree,
 
         // interpolate up clusters, level by level
         for (int level = 0; level < tree->max_depth; ++level) {
-            printf("Interpolating for level %i\n", level);
+
             for (int cluster_index = 0; cluster_index < tree->levels_list_num[level]; ++cluster_index) {
 
                 int parent_index = tree->levels_list[level][cluster_index];
@@ -78,7 +78,7 @@ void InteractionCompute_Downpass(double *potential, struct Tree *tree,
         }
 
         // interpolate from leaf cluster interpolation points to target particles
-        printf("Interpolating from leaf interpolation points to particles.\n");
+
         for (int i = 0; i < tree->leaves_list_num; ++i) {
             int leaf_index = tree->leaves_list[i];
             cp_comp_pot(tree, leaf_index, potential, interp_degree,
@@ -90,7 +90,7 @@ void InteractionCompute_Downpass(double *potential, struct Tree *tree,
 
         // interpolate up clusters, level by level
         for (int level = 0; level < tree->max_depth; ++level) {
-            printf("Interpolating for level %i\n", level);
+
             for (int cluster_index = 0; cluster_index < tree->levels_list_num[level]; ++cluster_index) {
 
                 int parent_index = tree->levels_list[level][cluster_index];
@@ -106,7 +106,7 @@ void InteractionCompute_Downpass(double *potential, struct Tree *tree,
         }
 
         // interpolate from leaf cluster interpolation points to target particles
-        printf("Interpolating from leaf interpolation points to particles.\n");
+
         for (int i = 0; i < tree->leaves_list_num; ++i) {
             int leaf_index = tree->leaves_list[i];
             cp_comp_pot_SS(tree, leaf_index, potential, interp_degree,

--- a/src/tree/tree.c
+++ b/src/tree/tree.c
@@ -83,7 +83,6 @@ void Tree_Targets_Construct(struct Tree **tree_addr, struct Particles *targets, 
                     run_params->max_per_target_leaf, xyzminmax, &numnodes, &numleaves,
                     &min_leaf_size, &max_leaf_size, &max_depth, 0);
     
-    printf("TreeLinkedList_Targets_Construct complete.\n");
 
     TreeLinkedList_SetIndex(tree_linked_list, 0);
     

--- a/src/tree/tree_linked_list.c
+++ b/src/tree/tree_linked_list.c
@@ -46,7 +46,6 @@ void TreeLinkedList_Targets_Construct(struct TreeLinkedListNode **p, struct Tree
     (*p)->numpar = iend - ibeg + 1;
 
     if (current_level + 1 > *max_depth){
-        printf("[TreeLinkedList_Targets_Construct] Increasing max depth to %i\n",current_level + 1);
         *max_depth = current_level + 1;
     }
     (*p)->level = current_level;


### PR DESCRIPTION
RunParams struct wasn't being passed in the .h file or the calls in treedriver, but it was expected (and used) in the .c.