### PR TITLE
Fixed SS on GPUs, was missing reductions

### DIFF
--- a/src/clusters/clusters.c
+++ b/src/clusters/clusters.c
@@ -573,7 +573,7 @@ void pc_comp_ms_modifiedF_SS_child_to_parent(const struct Tree *tree, int child_
 
 #ifdef OPENACC_ENABLED
     int streamID = rand() % 4;
-    #pragma acc kernels async(streamID) present(clusterX, clusterY, clusterZ, clusterQ) \
+    #pragma acc kernels async(streamID) present(clusterX, clusterY, clusterZ, clusterQ, clusterW) \
                        create(modifiedF[0:interpolationPointsPerCluster], modifiedF2[0:interpolationPointsPerCluster], exactIndX[0:interpolationPointsPerCluster], \
                               exactIndY[0:interpolationPointsPerCluster], exactIndZ[0:interpolationPointsPerCluster], \
                               nodeX[0:interpDegreeLim], nodeY[0:interpDegreeLim], \
@@ -694,7 +694,7 @@ void pc_comp_ms_modifiedF_SS_child_to_parent(const struct Tree *tree, int child_
         double temp = 0.0;
         double temp2 = 0.0;
 #ifdef OPENACC_ENABLED
-        #pragma acc loop vector(32) reduction(+:temp)
+        #pragma acc loop vector(32) reduction(+:temp) reduction(+:temp2)
 #endif
         for (int i = 0; i < interpolationPointsPerCluster; i++) {  // loop over source points
             double sx = clusterX[child_startingIndexInClustersArray + i];

--- a/src/interaction_compute/interaction_compute_downpass.c
+++ b/src/interaction_compute/interaction_compute_downpass.c
@@ -608,7 +608,7 @@ void cp_comp_pot_SS_parent_to_child(struct Tree *tree, int parent_index, int chi
         double temp2 = 0.0;
         
 #ifdef OPENACC_ENABLED
-        #pragma acc loop independent reduction(+:temp)
+        #pragma acc loop independent reduction(+:temp) reduction(+:temp2)
 #endif
         for (int j = 0; j < interp_pts_per_cluster; j++) { // loop over interpolation points, set (cx,cy,cz) for this point
 


### PR DESCRIPTION
Singularity subtraction kernels now working with O(N) upward and downward passes on GPUs.  Previously were only working on CPUs.  This was fixed by adding in missing reduction clauses for the GPU versions.